### PR TITLE
On Android phones with higher density and newer screens the buttons a…

### DIFF
--- a/app/src/main/jni/tuxpaint/src/tuxpaint.c
+++ b/app/src/main/jni/tuxpaint/src/tuxpaint.c
@@ -888,6 +888,14 @@ static void setup_normal_screen_layout(void)
     setup_normal_screen_layout();
   }
 
+#ifdef __ANDROID__
+  /* On Android the buttons can end up way too small on newer high density screens. */
+  if ((float)button_w / (float)WINDOW_WIDTH < 0.045) {
+    button_scale += 0.25;
+    setup_normal_screen_layout();
+  }
+#endif
+
   gd_tools.rows = buttons_tall;
   gd_toolopt.rows = buttons_tall;
 


### PR DESCRIPTION
…re so small they cannot be touched at all.

In testing this with an actual child on a S8+ (1440x2960 with 529ppi) and a S22+ (1080x2340 with 393ppi) the sweet spot appears to be buttons tha take up no less than 4.5% of the screen width. Below this they appear to be unusuable, and above this there's too much scroll of the toolbars.

 Button scale is incremented by 25% on each pass until the condition is met.